### PR TITLE
chore: resync with upstream — dynamic port, auth, GenSpace delete UI

### DIFF
--- a/backend/app_factory.py
+++ b/backend/app_factory.py
@@ -2,12 +2,16 @@
 
 from __future__ import annotations
 
+import base64
+import hmac
+from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING
 
 from fastapi import FastAPI, Request
 from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
+from starlette.responses import Response as StarletteResponse
 
 from _routes._errors import HTTPError
 from _routes.generation import router as generation_router
@@ -45,6 +49,7 @@ def create_app(
     handler: "AppHandler",
     allowed_origins: list[str] | None = None,
     title: str = "LTX-2 Video Generation Server",
+    auth_token: str = "",
 ) -> FastAPI:
     """Create a configured FastAPI app bound to the provided handler."""
     init_state_service(handler)
@@ -56,6 +61,38 @@ def create_app(
         allow_methods=["*"],
         allow_headers=["*"],
     )
+
+    @app.middleware("http")
+    async def _auth_middleware(  # pyright: ignore[reportUnusedFunction]
+        request: Request,
+        call_next: Callable[[Request], Awaitable[StarletteResponse]],
+    ) -> StarletteResponse:
+        if not auth_token:
+            return await call_next(request)
+        if request.method == "OPTIONS":
+            return await call_next(request)
+
+        def _token_matches(candidate: str) -> bool:
+            return hmac.compare_digest(candidate, auth_token)
+
+        # WebSocket: check query param
+        if request.headers.get("upgrade", "").lower() == "websocket":
+            if _token_matches(request.query_params.get("token", "")):
+                return await call_next(request)
+            return JSONResponse(status_code=401, content={"error": "Unauthorized"})
+        # HTTP: Bearer or Basic auth
+        auth_header = request.headers.get("authorization", "")
+        if auth_header.startswith("Bearer ") and _token_matches(auth_header[7:]):
+            return await call_next(request)
+        if auth_header.startswith("Basic "):
+            try:
+                decoded = base64.b64decode(auth_header[6:]).decode()
+                _, _, password = decoded.partition(":")
+                if _token_matches(password):
+                    return await call_next(request)
+            except Exception:
+                pass
+        return JSONResponse(status_code=401, content={"error": "Unauthorized"})
 
     async def _route_http_error_handler(request: Request, exc: Exception) -> JSONResponse:
         if isinstance(exc, HTTPError):

--- a/backend/ltx2_server.py
+++ b/backend/ltx2_server.py
@@ -99,7 +99,7 @@ if use_sage_attention:
 # Constants & Paths
 # ============================================================
 
-PORT = 8000
+PORT = 0  # 0 = pick a free port; Electron parses "Server running on ..." for the actual URL
 
 
 def _get_device() -> torch.device:
@@ -219,7 +219,8 @@ runtime_config = RuntimeConfig(
 )
 
 handler = build_initial_state(runtime_config, DEFAULT_APP_SETTINGS)
-app = create_app(handler=handler, allowed_origins=DEFAULT_ALLOWED_ORIGINS)
+auth_token = os.environ.get("LTX_AUTH_TOKEN", "")
+app = create_app(handler=handler, allowed_origins=DEFAULT_ALLOWED_ORIGINS, auth_token=auth_token)
 
 
 def precache_model_files(model_dir: Path) -> int:
@@ -267,9 +268,11 @@ def log_hardware_info() -> None:
 
 
 if __name__ == "__main__":
+    import asyncio
+    import socket as _socket
     import uvicorn
 
-    port = int(os.environ.get("LTX_PORT", PORT))
+    port = int(os.environ.get("LTX_PORT", "") or PORT)
     logger.info("=" * 60)
     logger.info("LTX-2 Video Generation Server (FastAPI + Uvicorn)")
     log_hardware_info()
@@ -281,8 +284,13 @@ if __name__ == "__main__":
     queue_thread = threading.Thread(target=queue_worker_loop, daemon=True)
     queue_thread.start()
 
-    # Use our root logging config so uvicorn logs go to stdout (not its
-    # default stderr), letting Electron tag them correctly as INFO.
+    # Bind the socket ourselves so we know the actual port before uvicorn starts.
+    # Electron parses the "Server running on ..." line to get the backend URL.
+    sock = _socket.socket(_socket.AF_INET, _socket.SOCK_STREAM)
+    sock.setsockopt(_socket.SOL_SOCKET, _socket.SO_REUSEADDR, 1)
+    sock.bind(("127.0.0.1", port))
+    actual_port = int(sock.getsockname()[1])
+
     log_config: dict[str, object] = {
         "version": 1,
         "disable_existing_loggers": False,
@@ -298,4 +306,18 @@ if __name__ == "__main__":
             "uvicorn.access": {"handlers": ["default"], "level": "INFO", "propagate": False},
         },
     }
-    uvicorn.run(app, host="127.0.0.1", port=port, log_level="info", access_log=False, log_config=log_config)
+    config = uvicorn.Config(
+        app, host="127.0.0.1", port=actual_port, log_level="info", access_log=False, log_config=log_config
+    )
+    server = uvicorn.Server(config)
+
+    _orig_startup = server.startup
+
+    async def _startup_with_ready_msg(sockets: list[_socket.socket] | None = None) -> None:
+        await _orig_startup(sockets=sockets)
+        if server.started:
+            print(f"Server running on http://127.0.0.1:{actual_port}", flush=True)
+
+    server.startup = _startup_with_ready_msg  # type: ignore[assignment]
+
+    asyncio.run(server.serve(sockets=[sock]))

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -1,0 +1,74 @@
+"""Tests for shared-secret authentication middleware."""
+
+from __future__ import annotations
+
+import base64
+
+from starlette.testclient import TestClient
+
+from app_factory import create_app
+
+
+def test_request_without_token_returns_401(test_state):  # noqa: ANN001
+    app = create_app(handler=test_state, auth_token="test-secret")
+    with TestClient(app) as client:
+        response = client.get("/health")
+        assert response.status_code == 401
+        assert response.json() == {"error": "Unauthorized"}
+
+
+def test_request_with_correct_bearer_token(test_state):  # noqa: ANN001
+    app = create_app(handler=test_state, auth_token="test-secret")
+    with TestClient(app) as client:
+        response = client.get("/health", headers={"Authorization": "Bearer test-secret"})
+        assert response.status_code == 200
+
+
+def test_request_with_correct_basic_auth(test_state):  # noqa: ANN001
+    app = create_app(handler=test_state, auth_token="test-secret")
+    credentials = base64.b64encode(b":test-secret").decode()
+    with TestClient(app) as client:
+        response = client.get("/health", headers={"Authorization": f"Basic {credentials}"})
+        assert response.status_code == 200
+
+
+def test_request_with_wrong_token_returns_401(test_state):  # noqa: ANN001
+    app = create_app(handler=test_state, auth_token="test-secret")
+    with TestClient(app) as client:
+        response = client.get("/health", headers={"Authorization": "Bearer wrong-token"})
+        assert response.status_code == 401
+
+
+def test_health_without_token_returns_401(test_state):  # noqa: ANN001
+    """Health endpoint is NOT exempt from auth."""
+    app = create_app(handler=test_state, auth_token="test-secret")
+    with TestClient(app) as client:
+        response = client.get("/health")
+        assert response.status_code == 401
+
+
+def test_no_auth_token_disables_middleware(test_state):  # noqa: ANN001
+    """When auth_token is empty string, auth is disabled (dev/test mode)."""
+    app = create_app(handler=test_state, auth_token="")
+    with TestClient(app) as client:
+        response = client.get("/health")
+        assert response.status_code == 200
+
+
+def test_websocket_with_token_query_param(test_state):  # noqa: ANN001
+    app = create_app(handler=test_state, auth_token="test-secret")
+    with TestClient(app) as client:
+        # WebSocket upgrade without token should fail with 401
+        response = client.get(
+            "/ws/download/test",
+            headers={"upgrade": "websocket", "connection": "upgrade"},
+        )
+        assert response.status_code == 401
+
+        # WebSocket upgrade with correct token query param
+        response = client.get(
+            "/ws/download/test?token=test-secret",
+            headers={"upgrade": "websocket", "connection": "upgrade"},
+        )
+        # The route may not exist, but auth should pass (not 401)
+        assert response.status_code != 401

--- a/electron/config.ts
+++ b/electron/config.ts
@@ -2,8 +2,6 @@ import { app } from 'electron'
 import path from 'path'
 import os from 'os'
 
-export const PYTHON_PORT = 8000
-export const BACKEND_BASE_URL = `http://localhost:${PYTHON_PORT}`
 export const isDev = !app.isPackaged
 
 // Get directory - works in both CJS and ESM contexts

--- a/electron/gpu.ts
+++ b/electron/gpu.ts
@@ -1,15 +1,18 @@
 import { execSync } from 'child_process'
-import { BACKEND_BASE_URL } from './config'
 import { logger } from './logger'
-import { getPythonPath } from './python-backend'
+import { getAuthToken, getBackendUrl, getPythonPath } from './python-backend'
 
 // Check if NVIDIA GPU is available
 export async function checkGPU(): Promise<{ available: boolean; name?: string; vram?: number }> {
   try {
-    // Try to get GPU info from the backend API first (more reliable)
-    const response = await fetch(`${BACKEND_BASE_URL}/api/gpu-info`, {
+    const url = getBackendUrl()
+    if (!url) throw new Error('Backend URL not available yet')
+    const headers: Record<string, string> = { 'Content-Type': 'application/json' }
+    const token = getAuthToken()
+    if (token) headers['Authorization'] = `Bearer ${token}`
+    const response = await fetch(`${url}/api/gpu-info`, {
       method: 'GET',
-      headers: { 'Content-Type': 'application/json' },
+      headers,
     })
 
     if (response.ok) {

--- a/electron/ipc/app-handlers.ts
+++ b/electron/ipc/app-handlers.ts
@@ -1,10 +1,9 @@
 import { app, ipcMain } from 'electron'
 import path from 'path'
 import fs from 'fs'
-import { BACKEND_BASE_URL } from '../config'
 import { checkGPU } from '../gpu'
 import { isPythonReady, downloadPythonEmbed } from '../python-setup'
-import { getBackendHealthStatus, startPythonBackend } from '../python-backend'
+import { getBackendHealthStatus, getBackendUrl, getAuthToken, startPythonBackend } from '../python-backend'
 import { getMainWindow } from '../window'
 import { getAnalyticsState, setAnalyticsEnabled, sendAnalyticsEvent } from '../analytics'
 
@@ -68,8 +67,8 @@ function markLicenseAccepted(settingsPath: string): void {
 }
 
 export function registerAppHandlers(): void {
-  ipcMain.handle('get-backend-url', () => {
-    return BACKEND_BASE_URL
+  ipcMain.handle('get-backend', () => {
+    return { url: getBackendUrl() ?? '', token: getAuthToken() ?? '' }
   })
 
   ipcMain.handle('get-models-path', () => {

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -3,8 +3,8 @@ const { contextBridge, ipcRenderer } = require('electron')
 
 // Expose protected methods to the renderer process
 contextBridge.exposeInMainWorld('electronAPI', {
-  // Get the backend URL
-  getBackendUrl: (): Promise<string> => ipcRenderer.invoke('get-backend-url'),
+  // Get the backend URL and auth token (empty token when auth disabled)
+  getBackend: (): Promise<{ url: string; token: string }> => ipcRenderer.invoke('get-backend'),
   
   // Get the path where models are stored
   getModelsPath: (): Promise<string> => ipcRenderer.invoke('get-models-path'),
@@ -141,7 +141,7 @@ interface BackendHealthStatus {
 declare global {
   interface Window {
     electronAPI: {
-      getBackendUrl: () => Promise<string>
+      getBackend: () => Promise<{ url: string; token: string }>
       getModelsPath: () => Promise<string>
       readLocalFile: (filePath: string) => Promise<{ data: string; mimeType: string }>
       checkGpu: () => Promise<{ available: boolean; name?: string; vram?: number }>

--- a/electron/python-backend.ts
+++ b/electron/python-backend.ts
@@ -1,8 +1,9 @@
 import { ChildProcess, spawn } from 'child_process'
+import crypto from 'crypto'
 import fs from 'fs'
 import path from 'path'
 import { getAppDataDir } from './app-paths'
-import { BACKEND_BASE_URL, getCurrentDir, isDev, PYTHON_PORT } from './config'
+import { getCurrentDir, isDev } from './config'
 import { logger, writeLog } from './logger'
 import { getPythonDir } from './python-setup'
 import { getMainWindow } from './window'
@@ -14,9 +15,22 @@ const CRASH_DEBOUNCE_MS = 10_000
 let startPromise: Promise<void> | null = null
 let takeoverInFlight: Promise<void> | null = null
 
+/** Resolved backend URL after "Server running on ..." is printed; used for health checks and frontend. */
+let resolvedBackendUrl: string | null = null
+/** Auth token passed to backend and frontend; empty when auth is disabled. */
+let backendAuthToken: string = ''
+
 type BackendOwnership = 'managed' | 'adopted' | null
 
 let backendOwnership: BackendOwnership = null
+
+export function getBackendUrl(): string | null {
+  return resolvedBackendUrl
+}
+
+export function getAuthToken(): string {
+  return backendAuthToken
+}
 
 export interface BackendHealthStatus {
   status: 'alive' | 'restarting' | 'dead'
@@ -51,12 +65,14 @@ function isPortConflictOutput(output: string): boolean {
 }
 
 async function probeBackendHealth(timeoutMs = 1500): Promise<boolean> {
+  const url = getBackendUrl()
+  if (!url) return false
   const controller = new AbortController()
   const timeout = setTimeout(() => controller.abort(), timeoutMs)
   try {
-    const response = await fetch(`${BACKEND_BASE_URL}/health`, {
-      signal: controller.signal,
-    })
+    const headers: Record<string, string> = { 'Content-Type': 'application/json' }
+    if (backendAuthToken) headers['Authorization'] = `Bearer ${backendAuthToken}`
+    const response = await fetch(`${url}/health`, { signal: controller.signal, headers })
     return response.ok
   } catch {
     return false
@@ -66,12 +82,17 @@ async function probeBackendHealth(timeoutMs = 1500): Promise<boolean> {
 }
 
 async function requestAdoptedBackendShutdown(timeoutMs = 2000): Promise<boolean> {
+  const url = getBackendUrl()
+  if (!url) return false
   const controller = new AbortController()
   const timeout = setTimeout(() => controller.abort(), timeoutMs)
   try {
-    const response = await fetch(`${BACKEND_BASE_URL}/api/system/shutdown`, {
+    const headers: Record<string, string> = { 'Content-Type': 'application/json' }
+    if (backendAuthToken) headers['Authorization'] = `Bearer ${backendAuthToken}`
+    const response = await fetch(`${url}/api/system/shutdown`, {
       method: 'POST',
       signal: controller.signal,
+      headers,
     })
     return response.ok
   } catch {
@@ -216,13 +237,17 @@ export async function startPythonBackend(): Promise<void> {
       pythonArgs = isDev ? ['-Xfrozen_modules=off', '-u', mainPy] : ['-u', mainPy]
     }
 
+    // Dynamic port: backend binds to 0 and prints "Server running on http://127.0.0.1:PORT"
+    resolvedBackendUrl = null
+    backendAuthToken = crypto.randomBytes(32).toString('hex')
+
     pythonProcess = spawn(pythonPath, pythonArgs, {
       cwd: backendPath,
       env: {
         ...process.env,
         PYTHONUNBUFFERED: '1',
         PYTHONNOUSERSITE: '1',
-        LTX_PORT: String(PYTHON_PORT),
+        LTX_AUTH_TOKEN: backendAuthToken,
         LTX_APP_DATA_DIR: getAppDataDir(),
         PYTORCH_ENABLE_MPS_FALLBACK: '1',
         // Set PYTHONHOME for bundled Python on macOS so it finds its stdlib
@@ -249,13 +274,17 @@ export async function startPythonBackend(): Promise<void> {
       reject(error)
     }
 
+    const serverReadyMatch = /Server running on (http:\/\/127\.0\.0\.1:\d+)/
+
     const checkStarted = (output: string) => {
       if (isPortConflictOutput(output)) {
         sawPortConflict = true
       }
 
-      // Check if server has started
-      if (!started && (output.includes('Server running on') || output.includes('Uvicorn running'))) {
+      // Backend prints "Server running on http://127.0.0.1:PORT" when ready (dynamic port)
+      const match = output.match(serverReadyMatch)
+      if (!started && match) {
+        resolvedBackendUrl = match[1]
         started = true
         backendOwnership = 'managed'
         publishBackendHealthStatus({ status: 'alive' })
@@ -295,6 +324,7 @@ export async function startPythonBackend(): Promise<void> {
     pythonProcess.on('exit', async (code) => {
       logger.info(`Python backend exited with code ${code}`)
       pythonProcess = null
+      resolvedBackendUrl = null
 
       if (!started) {
         if (isIntentionalShutdown) {
@@ -370,6 +400,7 @@ export async function startPythonBackend(): Promise<void> {
 export function stopPythonBackend(): void {
   if (pythonProcess) {
     isIntentionalShutdown = true
+    resolvedBackendUrl = null
     logger.info('Stopping Python backend...')
     const pid = pythonProcess.pid
     pythonProcess.kill('SIGTERM')

--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -23,6 +23,7 @@ import { LogViewer } from './components/LogViewer'
 import { ApiGatewayModal, type ApiGatewaySection } from './components/ApiGatewayModal'
 import { ErrorBoundary } from './components/ErrorBoundary'
 import { Button } from './components/ui/button'
+import { backendFetch } from './lib/backend'
 
 type SetupState = 'loading' | { needsSetup: boolean; needsLicense: boolean }
 type RequiredModelsGateState = 'checking' | 'missing' | 'ready'
@@ -189,8 +190,7 @@ function AppContent() {
     isForcedFirstRun && isLoaded && settings.hasLtxApiKey && !isFinalizingFirstRun && !firstRunFinalizeError
 
   const areRequiredModelsDownloaded = useCallback(async () => {
-    const backendUrl = await window.electronAPI.getBackendUrl()
-    const response = await fetch(`${backendUrl}/api/models/status`)
+    const response = await backendFetch('/api/models/status')
     if (!response.ok) {
       throw new Error(`Model status fetch failed with status ${response.status}`)
     }

--- a/frontend/components/FirstRunSetup.tsx
+++ b/frontend/components/FirstRunSetup.tsx
@@ -114,9 +114,9 @@ export function LaunchGate({
 
         // Get models path from backend
         try {
-          const url = await window.electronAPI.getBackendUrl()
+          const { url } = await window.electronAPI.getBackend()
           setBackendUrl(url)
-          const response = await fetch(`${url}/api/models/status`)
+          const response = await (await import('../lib/backend')).backendFetch('/api/models/status')
           if (response.ok) {
             const data = await response.json()
             if (data.models_path) {
@@ -156,7 +156,7 @@ export function LaunchGate({
 
     const pollProgress = async () => {
       try {
-        const response = await fetch(`${backendUrl}/api/models/download/progress`)
+        const response = await (await import('../lib/backend')).backendFetch('/api/models/download/progress')
         if (response.ok) {
           const progress = await response.json()
           setDownloadProgress(progress)
@@ -185,7 +185,7 @@ export function LaunchGate({
       // If API key is provided, save it to settings first and skip text encoder download
       if (ltxApiKey.trim()) {
         try {
-          await fetch(`${backendUrl}/api/settings`, {
+          await (await import('../lib/backend')).backendFetch('/api/settings', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ ltxApiKey: ltxApiKey.trim() }),
@@ -196,7 +196,7 @@ export function LaunchGate({
       }
 
       // Start download - skip text encoder if API key is provided
-      await fetch(`${backendUrl}/api/models/download`, {
+      await (await import('../lib/backend')).backendFetch('/api/models/download', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ skipTextEncoder: !!ltxApiKey.trim() }),

--- a/frontend/components/ICLoraPanel.tsx
+++ b/frontend/components/ICLoraPanel.tsx
@@ -3,6 +3,7 @@ import {
   X, Play, Pause, Upload, Loader2, Film, Sparkles,
   FolderOpen, ChevronDown, RefreshCw, Settings, Download, Check, AlertCircle,
 } from 'lucide-react'
+import { backendFetch } from '../lib/backend'
 import { logger } from '../lib/logger'
 
 interface ICLoraModel {
@@ -136,8 +137,7 @@ export function ICLoraPanel({
   // Fetch available models
   const fetchModels = useCallback(async () => {
     try {
-      const backendUrl = await window.electronAPI.getBackendUrl()
-      const resp = await fetch(`${backendUrl}/api/ic-lora/list-models`)
+      const resp = await backendFetch('/api/ic-lora/list-models')
       if (resp.ok) {
         const data = await resp.json()
         setModels(data.models || [])
@@ -155,8 +155,7 @@ export function ICLoraPanel({
     if (!inputVideoPath || isExtracting) return
     setIsExtracting(true)
     try {
-      const backendUrl = await window.electronAPI.getBackendUrl()
-      const resp = await fetch(`${backendUrl}/api/ic-lora/extract-conditioning`, {
+      const resp = await backendFetch('/api/ic-lora/extract-conditioning', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
@@ -254,8 +253,7 @@ export function ICLoraPanel({
     if (downloadingModels[modelDef.id] === 'downloading') return
     setDownloadingModels(prev => ({ ...prev, [modelDef.id]: 'downloading' }))
     try {
-      const backendUrl = await window.electronAPI.getBackendUrl()
-      const resp = await fetch(`${backendUrl}/api/ic-lora/download-model`, {
+      const resp = await backendFetch('/api/ic-lora/download-model', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ model: modelDef.id }),
@@ -302,9 +300,8 @@ export function ICLoraPanel({
     setOutputVideoPath(null)
 
     try {
-      const backendUrl = await window.electronAPI.getBackendUrl()
       setGenerationStatus('Generating video with IC-LoRA...')
-      const resp = await fetch(`${backendUrl}/api/ic-lora/generate`, {
+      const resp = await backendFetch('/api/ic-lora/generate', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({

--- a/frontend/components/ModelStatusDropdown.tsx
+++ b/frontend/components/ModelStatusDropdown.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef } from 'react'
 import { Loader2, CheckCircle2, Download, Clock, ChevronDown, AlertCircle } from 'lucide-react'
+import { backendFetch, getBackend } from '../lib/backend'
 import { logger } from '../lib/logger'
 
 interface ModelInfo {
@@ -47,7 +48,7 @@ export function ModelStatusDropdown({ className = '' }: ModelStatusDropdownProps
 
   // Fetch backend URL once on mount
   useEffect(() => {
-    window.electronAPI.getBackendUrl().then(setBackendUrl)
+    getBackend().then(({ url }) => setBackendUrl(url)).catch(() => setBackendUrl(null))
   }, [])
 
   // Fetch models status periodically
@@ -56,7 +57,7 @@ export function ModelStatusDropdown({ className = '' }: ModelStatusDropdownProps
 
     const fetchModelsStatus = async () => {
       try {
-        const response = await fetch(`${backendUrl}/api/models/status`)
+        const response = await backendFetch('/api/models/status')
         if (response.ok) {
           setModelsStatus(await response.json())
         }
@@ -76,7 +77,7 @@ export function ModelStatusDropdown({ className = '' }: ModelStatusDropdownProps
 
     const pollProgress = async () => {
       try {
-        const response = await fetch(`${backendUrl}/api/models/download/progress`)
+        const response = await backendFetch('/api/models/download/progress')
         if (response.ok) {
           setDownloadProgress(await response.json())
         }
@@ -137,7 +138,7 @@ export function ModelStatusDropdown({ className = '' }: ModelStatusDropdownProps
   const startDownload = async () => {
     if (!backendUrl) return
     try {
-      await fetch(`${backendUrl}/api/models/download`, {
+      await backendFetch('/api/models/download', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({}),

--- a/frontend/components/SettingsModal.tsx
+++ b/frontend/components/SettingsModal.tsx
@@ -62,10 +62,10 @@ export function SettingsModal({ isOpen, onClose, initialTab }: SettingsModalProp
     let cancelled = false
     const fetchStatus = async () => {
       try {
-        const backendUrl = await window.electronAPI.getBackendUrl()
+        const { backendFetch } = await import('../lib/backend')
         const [statusRes, creditsRes] = await Promise.all([
-          fetch(`${backendUrl}/api/sync/status`),
-          fetch(`${backendUrl}/api/sync/credits`),
+          backendFetch('/api/sync/status'),
+          backendFetch('/api/sync/credits'),
         ])
         if (cancelled) return
         if (statusRes.ok) setPaletteStatus(await statusRes.json())
@@ -113,8 +113,7 @@ export function SettingsModal({ isOpen, onClose, initialTab }: SettingsModalProp
 
     const fetchStatus = async () => {
       try {
-        const backendUrl = await window.electronAPI.getBackendUrl()
-        const response = await fetch(`${backendUrl}/api/models/status`)
+        const response = await (await import('../lib/backend')).backendFetch('/api/models/status')
         if (response.ok) {
           const data = await response.json()
           setTextEncoderStatus(data.text_encoder_status)
@@ -135,8 +134,7 @@ export function SettingsModal({ isOpen, onClose, initialTab }: SettingsModalProp
     setIsDownloading(true)
     setDownloadError(null)
     try {
-      const backendUrl = await window.electronAPI.getBackendUrl()
-      const response = await fetch(`${backendUrl}/api/text-encoder/download`, { method: 'POST' })
+      const response = await (await import('../lib/backend')).backendFetch('/api/text-encoder/download', { method: 'POST' })
       const data = await response.json()
 
       if (data.status === 'already_downloaded') {
@@ -145,7 +143,7 @@ export function SettingsModal({ isOpen, onClose, initialTab }: SettingsModalProp
       // Poll for completion
       const pollInterval = setInterval(async () => {
         try {
-          const statusRes = await fetch(`${backendUrl}/api/models/status`)
+          const statusRes = await (await import('../lib/backend')).backendFetch('/api/models/status')
           if (statusRes.ok) {
             const statusData = await statusRes.json()
             setTextEncoderStatus(statusData.text_encoder_status)

--- a/frontend/contexts/AppSettingsContext.tsx
+++ b/frontend/contexts/AppSettingsContext.tsx
@@ -1,4 +1,5 @@
 import { createContext, useCallback, useContext, useEffect, useMemo, useState, type ReactNode } from 'react'
+import { backendFetch, getBackend } from '../lib/backend'
 
 export interface InferenceSettings {
   steps: number
@@ -110,7 +111,7 @@ export function AppSettingsProvider({ children }: { children: ReactNode }) {
   const [backendProcessStatus, setBackendProcessStatus] = useState<BackendProcessStatus | null>(null)
 
   useEffect(() => {
-    window.electronAPI.getBackendUrl().then(setBackendUrl).catch(() => setBackendUrl(null))
+    getBackend().then(({ url }) => setBackendUrl(url)).catch(() => setBackendUrl(null))
   }, [])
 
   useEffect(() => {
@@ -121,7 +122,7 @@ export function AppSettingsProvider({ children }: { children: ReactNode }) {
 
     const fetchRuntimePolicy = async () => {
       try {
-        const response = await fetch(`${backendUrl}/api/runtime-policy`)
+        const response = await backendFetch('/api/runtime-policy')
         if (!response.ok) {
           throw new Error(`Runtime policy fetch failed with status ${response.status}`)
         }
@@ -184,7 +185,7 @@ export function AppSettingsProvider({ children }: { children: ReactNode }) {
 
   const refreshSettings = useCallback(async () => {
     if (!backendUrl) return
-    const response = await fetch(`${backendUrl}/api/settings`)
+    const response = await backendFetch('/api/settings')
     if (!response.ok) {
       throw new Error(`Settings fetch failed with status ${response.status}`)
     }
@@ -223,7 +224,7 @@ export function AppSettingsProvider({ children }: { children: ReactNode }) {
     const syncTimer = setTimeout(async () => {
       try {
         const { hasLtxApiKey: _a, hasReplicateApiKey: _b, hasGeminiApiKey: _c, hasPaletteApiKey: _d, ...syncPayload } = settings
-        await fetch(`${backendUrl}/api/settings`, {
+        await backendFetch('/api/settings', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(syncPayload),
@@ -245,7 +246,7 @@ export function AppSettingsProvider({ children }: { children: ReactNode }) {
 
   const saveLtxApiKey = useCallback(async (value: string) => {
     if (!backendUrl) return
-    const response = await fetch(`${backendUrl}/api/settings`, {
+    const response = await backendFetch('/api/settings', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ ltxApiKey: value }),
@@ -259,7 +260,7 @@ export function AppSettingsProvider({ children }: { children: ReactNode }) {
 
   const saveGeminiApiKey = useCallback(async (value: string) => {
     if (!backendUrl) return
-    const response = await fetch(`${backendUrl}/api/settings`, {
+    const response = await backendFetch('/api/settings', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ geminiApiKey: value }),
@@ -273,7 +274,7 @@ export function AppSettingsProvider({ children }: { children: ReactNode }) {
 
   const saveReplicateApiKey = useCallback(async (value: string) => {
     if (!backendUrl) return
-    const response = await fetch(`${backendUrl}/api/settings`, {
+    const response = await backendFetch('/api/settings', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ replicateApiKey: value }),
@@ -287,7 +288,7 @@ export function AppSettingsProvider({ children }: { children: ReactNode }) {
 
   const savePaletteApiKey = useCallback(async (value: string) => {
     if (!backendUrl) return
-    const response = await fetch(`${backendUrl}/api/settings`, {
+    const response = await backendFetch('/api/settings', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ paletteApiKey: value }),

--- a/frontend/hooks/use-backend.ts
+++ b/frontend/hooks/use-backend.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from 'react'
 import { logger } from '../lib/logger'
+import { backendFetch, backendWsUrl, getBackend } from '../lib/backend'
 
 interface BackendStatus {
   connected: boolean
@@ -65,9 +66,9 @@ export function useBackend(): UseBackendReturn {
 
   const checkHealth = useCallback(async (): Promise<boolean> => {
     try {
-      const backendUrl = await window.electronAPI.getBackendUrl()
-      logger.info(`Checking backend health at: ${backendUrl}`)
-      const response = await fetch(`${backendUrl}/health`)
+      const { url } = await getBackend()
+      logger.info(`Checking backend health at: ${url}`)
+      const response = await backendFetch('/health')
 
       if (response.ok) {
         const data = await response.json()
@@ -92,8 +93,7 @@ export function useBackend(): UseBackendReturn {
 
   const fetchModels = useCallback(async () => {
     try {
-      const backendUrl = await window.electronAPI.getBackendUrl()
-      const response = await fetch(`${backendUrl}/api/models`)
+      const response = await backendFetch('/api/models')
 
       if (response.ok) {
         const data = await response.json()
@@ -106,10 +106,8 @@ export function useBackend(): UseBackendReturn {
 
   const downloadModel = useCallback(async (modelId: string) => {
     try {
-      const backendUrl = await window.electronAPI.getBackendUrl()
-
-      // Connect to WebSocket for download progress
-      const wsUrl = backendUrl.replace('http://', 'ws://') + `/ws/download/${modelId}`
+      const { url, token } = await getBackend()
+      const wsUrl = backendWsUrl(url, `/ws/download/${modelId}`, token)
       const ws = new WebSocket(wsUrl)
 
       ws.onmessage = (event) => {
@@ -129,10 +127,7 @@ export function useBackend(): UseBackendReturn {
         }
       }
 
-      // Trigger download
-      await fetch(`${backendUrl}/api/models/${modelId}/download`, {
-        method: 'POST',
-      })
+      await backendFetch(`/api/models/${modelId}/download`, { method: 'POST' })
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Download failed')
     }

--- a/frontend/hooks/use-generation.ts
+++ b/frontend/hooks/use-generation.ts
@@ -1,6 +1,7 @@
 import { useState, useCallback, useRef, useEffect } from 'react'
 import type { GenerationSettings } from '../components/SettingsPanel'
 import { useAppSettings } from '../contexts/AppSettingsContext'
+import { backendFetch } from '../lib/backend'
 
 export interface QueueJob {
   id: string
@@ -127,8 +128,7 @@ export function useGeneration(): UseGenerationReturn {
 
     const poll = async () => {
       try {
-        const backendUrl = await window.electronAPI.getBackendUrl()
-        const res = await fetch(`${backendUrl}/api/queue/status`)
+        const res = await backendFetch('/api/queue/status')
         if (!res.ok) return
         const data: { jobs: QueueJob[] } = await res.json()
         const jobs: QueueJob[] = data.jobs
@@ -235,8 +235,6 @@ export function useGeneration(): UseGenerationReturn {
     }))
 
     try {
-      const backendUrl = await window.electronAPI.getBackendUrl()
-
       const params: Record<string, unknown> = {
         prompt,
         duration: String(settings.duration),
@@ -256,7 +254,7 @@ export function useGeneration(): UseGenerationReturn {
         params.lastFramePath = lastFramePath
       }
 
-      const response = await fetch(`${backendUrl}/api/queue/submit`, {
+      const response = await backendFetch('/api/queue/submit', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
@@ -288,8 +286,7 @@ export function useGeneration(): UseGenerationReturn {
     if (!jobId) return
 
     try {
-      const backendUrl = await window.electronAPI.getBackendUrl()
-      await fetch(`${backendUrl}/api/queue/cancel/${jobId}`, {
+      await backendFetch(`/api/queue/cancel/${jobId}`, {
         method: 'POST',
       })
     } catch {
@@ -309,8 +306,7 @@ export function useGeneration(): UseGenerationReturn {
   ) => {
     if (forceApiGenerations) {
       try {
-        const backendUrl = await window.electronAPI.getBackendUrl()
-        const response = await fetch(`${backendUrl}/api/settings`)
+        const response = await backendFetch('/api/settings')
         if (response.ok) {
           const payload = await response.json()
           if (!payload?.hasReplicateApiKey) {
@@ -356,12 +352,10 @@ export function useGeneration(): UseGenerationReturn {
     }))
 
     try {
-      const backendUrl = await window.electronAPI.getBackendUrl()
-
       const dims = getImageDimensions(settings)
       const numSteps = settings.imageSteps || 4
 
-      const response = await fetch(`${backendUrl}/api/queue/submit`, {
+      const response = await backendFetch('/api/queue/submit', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
@@ -396,8 +390,7 @@ export function useGeneration(): UseGenerationReturn {
 
   const clearQueue = useCallback(async () => {
     try {
-      const backendUrl = await window.electronAPI.getBackendUrl()
-      const res = await fetch(`${backendUrl}/api/queue/clear`, { method: 'POST' })
+      const res = await backendFetch('/api/queue/clear', { method: 'POST' })
       if (res.ok) {
         const data: { jobs: QueueJob[] } = await res.json()
         setState(prev => ({ ...prev, jobs: data.jobs }))

--- a/frontend/hooks/use-retake.ts
+++ b/frontend/hooks/use-retake.ts
@@ -1,4 +1,5 @@
 import { useCallback, useState } from 'react'
+import { backendFetch } from '../lib/backend'
 import { logger } from '../lib/logger'
 
 export type RetakeMode = 'replace_audio_and_video' | 'replace_video' | 'replace_audio'
@@ -42,8 +43,7 @@ export function useRetake() {
     })
 
     try {
-      const backendUrl = await window.electronAPI.getBackendUrl()
-      const response = await fetch(`${backendUrl}/api/retake`, {
+      const response = await backendFetch('/api/retake', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({

--- a/frontend/lib/backend.ts
+++ b/frontend/lib/backend.ts
@@ -1,0 +1,22 @@
+/**
+ * Backend URL and auth token (from Electron). Use for all HTTP and WebSocket calls.
+ * When token is empty, backend auth is disabled (e.g. dev).
+ */
+
+export async function getBackend(): Promise<{ url: string; token: string }> {
+  return window.electronAPI.getBackend()
+}
+
+export async function backendFetch(path: string, options: RequestInit = {}): Promise<Response> {
+  const { url, token } = await getBackend()
+  const headers = new Headers(options.headers)
+  if (token) headers.set('Authorization', `Bearer ${token}`)
+  return fetch(`${url}${path}`, { ...options, headers })
+}
+
+/** Build WebSocket URL with optional token query param for auth. */
+export function backendWsUrl(baseUrl: string, path: string, token: string): string {
+  const wsUrl = baseUrl.replace(/^http/, 'ws') + path
+  if (!token) return wsUrl
+  return `${wsUrl}${path.includes('?') ? '&' : '?'}token=${encodeURIComponent(token)}`
+}

--- a/frontend/views/Characters.tsx
+++ b/frontend/views/Characters.tsx
@@ -3,6 +3,7 @@ import { ArrowLeft, Plus, Pencil, Trash2, UserCircle, X } from 'lucide-react'
 import { useProjects } from '../contexts/ProjectContext'
 import { LtxLogo } from '../components/LtxLogo'
 import { Button } from '../components/ui/button'
+import { backendFetch } from '../lib/backend'
 import { logger } from '../lib/logger'
 
 /** Matches API: reference_image_paths are filesystem paths; we convert to file:// for <img src> */
@@ -42,8 +43,7 @@ export function Characters() {
     setLoading(true)
     setError(null)
     try {
-      const backendUrl = await window.electronAPI.getBackendUrl()
-      const res = await fetch(`${backendUrl}/api/library/characters`)
+      const res = await backendFetch('/api/library/characters')
       if (!res.ok) throw new Error(`Failed to fetch characters: ${res.status}`)
       const data = (await res.json()) as { characters: unknown[] }
       setCharacters(
@@ -94,7 +94,6 @@ export function Characters() {
     if (!formName.trim()) return
     setSaving(true)
     try {
-      const backendUrl = await window.electronAPI.getBackendUrl()
       const body = {
         name: formName.trim(),
         role: formRole.trim(),
@@ -102,14 +101,14 @@ export function Characters() {
         reference_image_paths: formImages,
       }
       if (editingCharacter) {
-        const res = await fetch(`${backendUrl}/api/library/characters/${editingCharacter.id}`, {
+        const res = await backendFetch(`/api/library/characters/${editingCharacter.id}`, {
           method: 'PUT',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(body),
         })
         if (!res.ok) throw new Error(`Update failed: ${res.status}`)
       } else {
-        const res = await fetch(`${backendUrl}/api/library/characters`, {
+        const res = await backendFetch('/api/library/characters', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(body),
@@ -128,8 +127,7 @@ export function Characters() {
   const handleDelete = async (char: Character) => {
     if (!confirm(`Delete character "${char.name}"?`)) return
     try {
-      const backendUrl = await window.electronAPI.getBackendUrl()
-      const res = await fetch(`${backendUrl}/api/library/characters/${char.id}`, { method: 'DELETE' })
+      const res = await backendFetch(`/api/library/characters/${char.id}`, { method: 'DELETE' })
       if (!res.ok) throw new Error(`Delete failed: ${res.status}`)
       setCharacters(prev => prev.filter(c => c.id !== char.id))
     } catch (e) {

--- a/frontend/views/Gallery.tsx
+++ b/frontend/views/Gallery.tsx
@@ -3,6 +3,7 @@ import { ArrowLeft, Image as ImageIcon, Film, Trash2, CloudUpload, Download, X, 
 import { useProjects } from '../contexts/ProjectContext'
 import { LtxLogo } from '../components/LtxLogo'
 import { Button } from '../components/ui/button'
+import { backendFetch } from '../lib/backend'
 import { logger } from '../lib/logger'
 
 type FilterType = 'all' | 'images' | 'videos'
@@ -57,8 +58,7 @@ export function Gallery() {
     setLoading(true)
     setError(null)
     try {
-      const backendUrl = await window.electronAPI.getBackendUrl()
-      const res = await fetch(`${backendUrl}/api/gallery/local?page=${page}&per_page=${perPage}&type=${filter}`)
+      const res = await backendFetch(`/api/gallery/local?page=${page}&per_page=${perPage}&type=${filter}`)
       if (!res.ok) throw new Error(`Failed to fetch gallery: ${res.status}`)
       const data = (await res.json()) as {
         items: Array<{
@@ -107,8 +107,7 @@ export function Gallery() {
   const handleDelete = async (item: GalleryItem) => {
     if (!confirm(`Delete "${item.filename}"?`)) return
     try {
-      const backendUrl = await window.electronAPI.getBackendUrl()
-      const res = await fetch(`${backendUrl}/api/gallery/local/${item.id}`, { method: 'DELETE' })
+      const res = await backendFetch(`/api/gallery/local/${item.id}`, { method: 'DELETE' })
       if (!res.ok) throw new Error(`Delete failed: ${res.status}`)
       setItems(prev => prev.filter(i => i.id !== item.id))
       setTotal(prev => prev - 1)

--- a/frontend/views/GenSpace.tsx
+++ b/frontend/views/GenSpace.tsx
@@ -164,27 +164,27 @@ function AssetCard({
         {/* Bottom controls for video */}
         {asset.type === 'video' && (
           <div className="absolute bottom-2 left-2 right-2 flex items-center justify-between">
-            <div className="px-2 py-1 rounded-lg bg-black/50 backdrop-blur-md text-white text-xs font-mono">
-              {formatTime(currentTime)}
+            <div className="flex items-center gap-1.5">
+              <div className="px-2 py-1 rounded-lg bg-black/50 backdrop-blur-md text-white text-xs font-mono">
+                {formatTime(currentTime)}
+              </div>
+              <button
+                onClick={(e) => { e.stopPropagation(); setIsMuted(!isMuted) }}
+                className="p-1.5 rounded-lg bg-black/40 backdrop-blur-md text-white hover:bg-black/60 transition-colors"
+              >
+                {isMuted ? <VolumeX className="h-3.5 w-3.5" /> : <Volume2 className="h-3.5 w-3.5" />}
+              </button>
             </div>
-            <button
-              onClick={(e) => { e.stopPropagation(); setIsMuted(!isMuted) }}
-              className="p-1.5 rounded-lg bg-black/40 backdrop-blur-md text-white hover:bg-black/60 transition-colors"
-            >
-              {isMuted ? <VolumeX className="h-3.5 w-3.5" /> : <Volume2 className="h-3.5 w-3.5" />}
-            </button>
           </div>
         )}
-        
-        {/* Delete button (subtle, bottom right for images) */}
-        {asset.type === 'image' && (
-          <button
-            onClick={(e) => { e.stopPropagation(); onDelete() }}
-            className="absolute bottom-2 right-2 p-1.5 rounded-lg bg-red-600/70 backdrop-blur-md text-white hover:bg-red-500 transition-colors opacity-0 group-hover:opacity-100"
-          >
-            <Trash2 className="h-3.5 w-3.5" />
-          </button>
-        )}
+
+        {/* Delete button (subtle, bottom right for all asset types) */}
+        <button
+          onClick={(e) => { e.stopPropagation(); onDelete() }}
+          className="absolute bottom-2 right-2 p-1.5 rounded-lg bg-black/40 backdrop-blur-md text-white/70 hover:bg-red-500/80 hover:text-white transition-colors opacity-0 group-hover:opacity-100"
+        >
+          <Trash2 className="h-3.5 w-3.5" />
+        </button>
       </div>
       
     </div>

--- a/frontend/views/Playground.tsx
+++ b/frontend/views/Playground.tsx
@@ -113,8 +113,7 @@ export function Playground() {
     if (!prompt.trim() || isEnhancing) return
     setIsEnhancing(true)
     try {
-      const backendUrl = await window.electronAPI.getBackendUrl()
-      const res = await fetch(`${backendUrl}/api/enhance-prompt`, {
+      const res = await (await import('../lib/backend')).backendFetch('/api/enhance-prompt', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ prompt, mode }),

--- a/frontend/views/PromptLibrary.tsx
+++ b/frontend/views/PromptLibrary.tsx
@@ -42,8 +42,7 @@ export function PromptLibrary() {
     setLoading(true)
     setError(null)
     try {
-      const backendUrl = await window.electronAPI.getBackendUrl()
-      const res = await fetch(`${backendUrl}/api/prompts`)
+      const res = await (await import('../lib/backend')).backendFetch('/api/prompts')
       if (!res.ok) throw new Error(`Failed to fetch prompts: ${res.status}`)
       const data = (await res.json()) as { prompts: SavedPrompt[] }
       setPrompts(data.prompts ?? [])
@@ -74,9 +73,8 @@ export function PromptLibrary() {
     if (!formText.trim()) return
     setSaving(true)
     try {
-      const backendUrl = await window.electronAPI.getBackendUrl()
       const tags = formTags.split(',').map(t => t.trim()).filter(Boolean)
-      const res = await fetch(`${backendUrl}/api/prompts`, {
+      const res = await (await import('../lib/backend')).backendFetch('/api/prompts', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ text: formText.trim(), tags }),

--- a/frontend/views/References.tsx
+++ b/frontend/views/References.tsx
@@ -3,6 +3,7 @@ import { ArrowLeft, Plus, Trash2, ImageIcon, X } from 'lucide-react'
 import { useProjects } from '../contexts/ProjectContext'
 import { LtxLogo } from '../components/LtxLogo'
 import { Button } from '../components/ui/button'
+import { backendFetch } from '../lib/backend'
 import { logger } from '../lib/logger'
 
 type Category = 'all' | 'people' | 'places' | 'props' | 'other'
@@ -38,9 +39,8 @@ export function References() {
     setLoading(true)
     setError(null)
     try {
-      const backendUrl = await window.electronAPI.getBackendUrl()
       const query = category !== 'all' ? `?category=${category}` : ''
-      const res = await fetch(`${backendUrl}/api/library/references${query}`)
+      const res = await backendFetch(`/api/library/references${query}`)
       if (!res.ok) throw new Error(`Failed to fetch references: ${res.status}`)
       const data = (await res.json()) as { references: unknown[] }
       setReferences(
@@ -79,8 +79,7 @@ export function References() {
     if (!formName.trim() || !formImage) return
     setSaving(true)
     try {
-      const backendUrl = await window.electronAPI.getBackendUrl()
-      const res = await fetch(`${backendUrl}/api/library/references`, {
+      const res = await backendFetch('/api/library/references', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
@@ -102,8 +101,7 @@ export function References() {
   const handleDelete = async (ref: Reference) => {
     if (!confirm(`Delete reference "${ref.name}"?`)) return
     try {
-      const backendUrl = await window.electronAPI.getBackendUrl()
-      const res = await fetch(`${backendUrl}/api/library/references/${ref.id}`, { method: 'DELETE' })
+      const res = await backendFetch(`/api/library/references/${ref.id}`, { method: 'DELETE' })
       if (!res.ok) throw new Error(`Delete failed: ${res.status}`)
       setReferences(prev => prev.filter(r => r.id !== ref.id))
     } catch (e) {

--- a/frontend/views/Styles.tsx
+++ b/frontend/views/Styles.tsx
@@ -3,6 +3,7 @@ import { ArrowLeft, Plus, Pencil, Trash2, Palette, X } from 'lucide-react'
 import { useProjects } from '../contexts/ProjectContext'
 import { LtxLogo } from '../components/LtxLogo'
 import { Button } from '../components/ui/button'
+import { backendFetch } from '../lib/backend'
 import { logger } from '../lib/logger'
 
 /** API uses reference_image_path (filesystem path); we convert to file:// for <img src>. */
@@ -36,8 +37,7 @@ export function Styles() {
     setLoading(true)
     setError(null)
     try {
-      const backendUrl = await window.electronAPI.getBackendUrl()
-      const res = await fetch(`${backendUrl}/api/library/styles`)
+      const res = await backendFetch('/api/library/styles')
       if (!res.ok) throw new Error(`Failed to fetch styles: ${res.status}`)
       const data = (await res.json()) as { styles: unknown[] }
       setStyles(
@@ -85,21 +85,20 @@ export function Styles() {
     if (!formName.trim()) return
     setSaving(true)
     try {
-      const backendUrl = await window.electronAPI.getBackendUrl()
       const body = {
         name: formName.trim(),
         description: formDescription.trim(),
         reference_image_path: formImage || '',
       }
       if (editingStyle) {
-        const res = await fetch(`${backendUrl}/api/library/styles/${editingStyle.id}`, {
+        const res = await backendFetch(`/api/library/styles/${editingStyle.id}`, {
           method: 'PUT',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(body),
         })
         if (!res.ok) throw new Error(`Update failed: ${res.status}`)
       } else {
-        const res = await fetch(`${backendUrl}/api/library/styles`, {
+        const res = await backendFetch('/api/library/styles', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(body),
@@ -118,8 +117,7 @@ export function Styles() {
   const handleDelete = async (style: Style) => {
     if (!confirm(`Delete style "${style.name}"?`)) return
     try {
-      const backendUrl = await window.electronAPI.getBackendUrl()
-      const res = await fetch(`${backendUrl}/api/library/styles/${style.id}`, { method: 'DELETE' })
+      const res = await backendFetch(`/api/library/styles/${style.id}`, { method: 'DELETE' })
       if (!res.ok) throw new Error(`Delete failed: ${res.status}`)
       setStyles(prev => prev.filter(s => s.id !== style.id))
     } catch (e) {

--- a/frontend/views/Wildcards.tsx
+++ b/frontend/views/Wildcards.tsx
@@ -3,6 +3,7 @@ import { ArrowLeft, Plus, Pencil, Trash2, Braces, X, Shuffle, ChevronDown, Chevr
 import { useProjects } from '../contexts/ProjectContext'
 import { LtxLogo } from '../components/LtxLogo'
 import { Button } from '../components/ui/button'
+import { backendFetch } from '../lib/backend'
 import { logger } from '../lib/logger'
 
 interface Wildcard {
@@ -30,8 +31,7 @@ export function Wildcards() {
     setLoading(true)
     setError(null)
     try {
-      const backendUrl = await window.electronAPI.getBackendUrl()
-      const res = await fetch(`${backendUrl}/api/wildcards`)
+      const res = await backendFetch('/api/wildcards')
       if (!res.ok) throw new Error(`Failed to fetch wildcards: ${res.status}`)
       const data = (await res.json()) as { wildcards: Wildcard[] }
       setWildcards(data.wildcards ?? [])
@@ -66,18 +66,17 @@ export function Wildcards() {
     if (!formName.trim() || !formValues.trim()) return
     setSaving(true)
     try {
-      const backendUrl = await window.electronAPI.getBackendUrl()
       const values = formValues.split('\n').map(v => v.trim()).filter(Boolean)
       const body = { name: formName.trim(), values }
       if (editingWildcard) {
-        const res = await fetch(`${backendUrl}/api/wildcards/${editingWildcard.id}`, {
+        const res = await backendFetch(`/api/wildcards/${editingWildcard.id}`, {
           method: 'PUT',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(body),
         })
         if (!res.ok) throw new Error(`Update failed: ${res.status}`)
       } else {
-        const res = await fetch(`${backendUrl}/api/wildcards`, {
+        const res = await backendFetch('/api/wildcards', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(body),
@@ -96,8 +95,7 @@ export function Wildcards() {
   const handleDelete = async (wc: Wildcard) => {
     if (!confirm(`Delete wildcard "_${wc.name}_"?`)) return
     try {
-      const backendUrl = await window.electronAPI.getBackendUrl()
-      const res = await fetch(`${backendUrl}/api/wildcards/${wc.id}`, { method: 'DELETE' })
+      const res = await backendFetch(`/api/wildcards/${wc.id}`, { method: 'DELETE' })
       if (!res.ok) throw new Error(`Delete failed: ${res.status}`)
       setWildcards(prev => prev.filter(w => w.id !== wc.id))
     } catch (e) {

--- a/frontend/views/editor/useGapGeneration.ts
+++ b/frontend/views/editor/useGapGeneration.ts
@@ -453,8 +453,7 @@ export function useGapGeneration({
         }
       }
       
-      const backendUrl = await window.electronAPI.getBackendUrl()
-      const response = await fetch(`${backendUrl}/api/suggest-gap-prompt`, {
+      const response = await (await import('../../lib/backend')).backendFetch('/api/suggest-gap-prompt', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({

--- a/frontend/views/editor/useRegeneration.ts
+++ b/frontend/views/editor/useRegeneration.ts
@@ -204,8 +204,7 @@ export function useRegeneration(params: UseRegenerationParams) {
 
         if (framePath) {
           // Ask Gemini to describe the frame
-          const backendUrl = await window.electronAPI.getBackendUrl()
-          const resp = await fetch(`${backendUrl}/api/suggest-gap-prompt`, {
+          const resp = await (await import('../../lib/backend')).backendFetch('/api/suggest-gap-prompt', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({

--- a/frontend/vite-env.d.ts
+++ b/frontend/vite-env.d.ts
@@ -13,7 +13,7 @@ interface BackendHealthStatus {
 
 interface Window {
   electronAPI: {
-    getBackendUrl: () => Promise<string>
+    getBackend: () => Promise<{ url: string; token: string }>
     getModelsPath: () => Promise<string>
     readLocalFile: (filePath: string) => Promise<{ data: string; mimeType: string }>
     checkGpu: () => Promise<{ available: boolean; name?: string; vram?: number }>

--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
       if (!window.electronAPI && location.protocol === 'http:') {
         const noop = () => Promise.resolve();
         window.electronAPI = {
-          getBackendUrl: () => Promise.resolve('http://localhost:8000'),
+          getBackend: () => Promise.resolve({ url: 'http://localhost:8000', token: '' }),
           getModelsPath: () => Promise.resolve('C:/models'),
           readLocalFile: () => Promise.resolve({ data: '', mimeType: 'image/png' }),
           checkGpu: () => Promise.resolve({ available: true, name: 'NVIDIA RTX 4090', vram: 24576 }),


### PR DESCRIPTION
Backport from Lightricks/LTX-Desktop:

- GenSpace (b55c1f7): Delete button on all asset types; mute next to time; subtle delete style (dark, red on hover).
- Dynamic port + auth (c6068da): Backend binds to port 0, prints 'Server running on http://127.0.0.1:PORT'; auth_token middleware (Bearer/Basic/WebSocket ?token=); Electron generates token, parses ready line, exposes getBackend() { url, token }; frontend uses backendFetch() and backendWsUrl() with Authorization / token.
- test_auth.py: Tests for 401 without token, Bearer/Basic, no-auth when token empty, WebSocket token query.
